### PR TITLE
Add .NET Standard 2.0 target and update Test project to .NET 6.0

### DIFF
--- a/src/OpenSource.Data.HashFunction.BernsteinHash/OpenSource.Data.HashFunction.BernsteinHash.csproj
+++ b/src/OpenSource.Data.HashFunction.BernsteinHash/OpenSource.Data.HashFunction.BernsteinHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.BernsteinHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.BernsteinHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.Blake2/OpenSource.Data.HashFunction.Blake2.csproj
+++ b/src/OpenSource.Data.HashFunction.Blake2/OpenSource.Data.HashFunction.Blake2.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.Blake2</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.Blake2</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.BuzHash/OpenSource.Data.HashFunction.BuzHash.csproj
+++ b/src/OpenSource.Data.HashFunction.BuzHash/OpenSource.Data.HashFunction.BuzHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.BuzHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.BuzHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.CRC/OpenSource.Data.HashFunction.CRC.csproj
+++ b/src/OpenSource.Data.HashFunction.CRC/OpenSource.Data.HashFunction.CRC.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.CRC</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.CRC</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.CityHash/OpenSource.Data.HashFunction.CityHash.csproj
+++ b/src/OpenSource.Data.HashFunction.CityHash/OpenSource.Data.HashFunction.CityHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.CityHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.CityHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.Core/OpenSource.Data.HashFunction.Core.csproj
+++ b/src/OpenSource.Data.HashFunction.Core/OpenSource.Data.HashFunction.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.Core</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.Core</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.ELF64/OpenSource.Data.HashFunction.ELF64.csproj
+++ b/src/OpenSource.Data.HashFunction.ELF64/OpenSource.Data.HashFunction.ELF64.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.ELF64</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.ELF64</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.FNV/OpenSource.Data.HashFunction.FNV.csproj
+++ b/src/OpenSource.Data.HashFunction.FNV/OpenSource.Data.HashFunction.FNV.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.FNV</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.FNV</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.FarmHash/OpenSource.Data.HashFunction.FarmHash.csproj
+++ b/src/OpenSource.Data.HashFunction.FarmHash/OpenSource.Data.HashFunction.FarmHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.FarmHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.FarmHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.Interfaces/OpenSource.Data.HashFunction.Interfaces.csproj
+++ b/src/OpenSource.Data.HashFunction.Interfaces/OpenSource.Data.HashFunction.Interfaces.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.Interfaces</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.Interfaces</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.Jenkins/OpenSource.Data.HashFunction.Jenkins.csproj
+++ b/src/OpenSource.Data.HashFunction.Jenkins/OpenSource.Data.HashFunction.Jenkins.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.Jenkins</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.Jenkins</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.MetroHash/OpenSource.Data.HashFunction.MetroHash.csproj
+++ b/src/OpenSource.Data.HashFunction.MetroHash/OpenSource.Data.HashFunction.MetroHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.MetroHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.MetroHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.MurmurHash/OpenSource.Data.HashFunction.MurmurHash.csproj
+++ b/src/OpenSource.Data.HashFunction.MurmurHash/OpenSource.Data.HashFunction.MurmurHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.MurmurHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.MurmurHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.Pearson/OpenSource.Data.HashFunction.Pearson.csproj
+++ b/src/OpenSource.Data.HashFunction.Pearson/OpenSource.Data.HashFunction.Pearson.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.Pearson</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.Pearson</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.SpookyHash/OpenSource.Data.HashFunction.SpookyHash.csproj
+++ b/src/OpenSource.Data.HashFunction.SpookyHash/OpenSource.Data.HashFunction.SpookyHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.SpookyHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.SpookyHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenSource.Data.HashFunction.Test/Core/IHashFunction_Extensions_Tests.cs
+++ b/src/OpenSource.Data.HashFunction.Test/Core/IHashFunction_Extensions_Tests.cs
@@ -296,7 +296,7 @@ namespace OpenSource.Data.HashFunction.Test
                     BitConverter.GetBytes(value));
             }
 
-#if !NETCOREAPP1_1
+#if !NET6_0_OR_GREATER
 
             [Fact]
             public void IHashFunction_Extensions_ComputeHash_WithDesiredBits_TModel()

--- a/src/OpenSource.Data.HashFunction.Test/OpenSource.Data.HashFunction.Test.csproj
+++ b/src/OpenSource.Data.HashFunction.Test/OpenSource.Data.HashFunction.Test.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.Test</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyName>OpenSource.Data.HashFunction.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>
@@ -14,7 +14,6 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>$(PackageIdPrefix).Data.HashFunction.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>

--- a/src/OpenSource.Data.HashFunction.xxHash/OpenSource.Data.HashFunction.xxHash.csproj
+++ b/src/OpenSource.Data.HashFunction.xxHash/OpenSource.Data.HashFunction.xxHash.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Data.HashFunction.xxHash</AssemblyTitle>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Data.HashFunction Developers</Authors>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>OpenSource.Data.HashFunction.xxHash</AssemblyName>
     <AssemblyOriginatorKeyFile>../Data.HashFunction.Production.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This stops pulling in all of .NET Standard 1.6.1 in newer project, avoiding pulling in vulnerable code by default and making container sizes larger.

This also updates the tests to run in net6.0 since netcoreapp1.1 is long been unsupported. .NET 8 (also an LTS) would be better but I'm not sure if your internal use of this would be ready for that.